### PR TITLE
fix: watch for structural changes on objects and arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- fix: watch for structural changes on objects and arrays #3
+
 ## [0.1.1] - 2024-11-22
 
 ### Changed

--- a/src/core.ts
+++ b/src/core.ts
@@ -73,7 +73,7 @@ export function watch(fn: () => void): Unwatch {
       }
       return !Object.is(value, prevValue);
     });
-  }
+  };
 
   const callback = () => {
     if (Array.from(touchedKeys).some(([p, prev]) => isChanged(p, prev))) {
@@ -85,7 +85,9 @@ export function watch(fn: () => void): Unwatch {
       if (currentKeys.length !== prevKeys.size) {
         return true;
       }
-      return !Array.from(prevKeys).every((key) => currentKeys.includes(key as string));
+      return !Array.from(prevKeys).every((key) =>
+        currentKeys.includes(key as string),
+      );
     });
     if (keysChanged) {
       runFn();

--- a/src/core.ts
+++ b/src/core.ts
@@ -72,12 +72,15 @@ export function watch(fn: () => void): Unwatch {
       if (prevOfValue) {
         return isChanged(value as ProxyObject, prevOfValue);
       }
+      if (!Object.is(value, prevValue[0])) {
+        return true;
+      }
       const version = getVersion(value);
       const prevVersion = prevValue[1];
       if (typeof version === 'number' && typeof prevVersion === 'number') {
         return version !== prevVersion;
       }
-      return !Object.is(value, prevValue[0]);
+      return false;
     });
 
   const callback = () => {

--- a/tests/01_watch.spec.ts
+++ b/tests/01_watch.spec.ts
@@ -80,8 +80,6 @@ describe('watch', () => {
         completed: false,
       },
     });
-    // list.todos["1"].completed = true;
-    // expect(fn).toHaveBeenCalledTimes(3);
     list.todos["2"] = {
       title: "Buy milk",
       completed: false,

--- a/tests/01_watch.spec.ts
+++ b/tests/01_watch.spec.ts
@@ -45,7 +45,7 @@ describe('watch', () => {
     unwatch();
   });
 
-  it('should work arrays', async () => {
+  it('should work with arrays', async () => {
     const state = proxy<{ items: number[] }>({ items: [] });
     const data: number[] = [];
     const unwatch = watch(() => {
@@ -62,31 +62,29 @@ describe('watch', () => {
   it('should work with objects', async () => {
     const fn = vi.fn();
     const list = proxy<{
-      todos: Record<string, { title: string; completed: boolean }>;
+      todos: Record<string, { title: string }>;
     }>({
       todos: {},
     });
     const unwatch = watch(() => {
       fn(list.todos);
     });
-    list.todos['1'] = {
-      title: 'Buy milk',
-      completed: false,
-    };
-    expect(fn).toHaveBeenCalledTimes(2);
-    expect(fn).toHaveBeenCalledWith({
-      '1': {
-        title: 'Buy milk',
-        completed: false,
-      },
+    fn.mockClear();
+    list.todos['1'] = { title: 'Buy milk' };
+    expect(fn).toHaveBeenCalledExactlyOnceWith({
+      '1': { title: 'Buy milk' },
     });
-    list.todos['2'] = {
-      title: 'Buy milk',
-      completed: false,
-    };
-    expect(fn).toHaveBeenCalledTimes(3);
+    fn.mockClear();
+    list.todos['2'] = { title: 'Buy coffee' };
+    expect(fn).toHaveBeenCalledExactlyOnceWith({
+      '1': { title: 'Buy milk' },
+      '2': { title: 'Buy coffee' },
+    });
+    fn.mockClear();
     delete list.todos['1'];
-    expect(fn).toHaveBeenCalledTimes(4);
+    expect(fn).toHaveBeenCalledExactlyOnceWith({
+      '2': { title: 'Buy coffee' },
+    });
     unwatch();
   });
 
@@ -96,10 +94,15 @@ describe('watch', () => {
     const unwatch = watch(() => {
       fn(state.items);
     });
+    fn.mockClear();
     state.items.push(1);
-    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenCalledExactlyOnceWith([1]);
+    fn.mockClear();
     state.items.push(2);
-    expect(fn).toHaveBeenCalledTimes(3);
+    expect(fn).toHaveBeenCalledExactlyOnceWith([1, 2]);
+    fn.mockClear();
+    state.items.shift();
+    expect(fn).toHaveBeenLastCalledWith([2]);
     unwatch();
   });
 });

--- a/tests/01_watch.spec.ts
+++ b/tests/01_watch.spec.ts
@@ -44,6 +44,66 @@ describe('watch', () => {
     expect(data).toEqual([0, 1]);
     unwatch();
   });
+
+  it('should work arrays', async () => {
+    const state = proxy<{ items: number[] }>({ items: [] });
+    const data: number[] = [];
+    const unwatch = watch(() => {
+      data.push(state.items.length);
+    });
+    expect(data).toEqual([0]);
+    state.items.push(1);
+    expect(data).toEqual([0, 1]);
+    state.items.push(2);
+    expect(data).toEqual([0, 1, 2]);
+    unwatch();
+  });
+
+  it('should work with objects', async () => {
+    const fn = vi.fn();
+    const list = proxy<{
+      todos: Record<string, { title: string; completed: boolean }>;
+    }>({
+      todos: {},
+    });
+    const unwatch = watch(() => {
+      fn(list.todos);
+    });
+    list.todos["1"] = {
+      title: "Buy milk",
+      completed: false,
+    };
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenCalledWith({
+      "1": {
+        title: "Buy milk",
+        completed: false,
+      },
+    });
+    // list.todos["1"].completed = true;
+    // expect(fn).toHaveBeenCalledTimes(3);
+    list.todos["2"] = {
+      title: "Buy milk",
+      completed: false,
+    };
+    expect(fn).toHaveBeenCalledTimes(3);
+    delete list.todos["1"];
+    expect(fn).toHaveBeenCalledTimes(4);
+    unwatch();
+  });
+
+  it('should watch arrays for structure changes', async () => {
+    const fn = vi.fn();
+    const state = proxy<{ items: number[] }>({ items: [] });
+    const unwatch = watch(() => {
+      fn(state.items);
+    });
+    state.items.push(1);
+    expect(fn).toHaveBeenCalledTimes(2);
+    state.items.push(2);
+    expect(fn).toHaveBeenCalledTimes(3);
+    unwatch();
+  })
 });
 
 describe('watch with batch', () => {

--- a/tests/01_watch.spec.ts
+++ b/tests/01_watch.spec.ts
@@ -69,23 +69,23 @@ describe('watch', () => {
     const unwatch = watch(() => {
       fn(list.todos);
     });
-    list.todos["1"] = {
-      title: "Buy milk",
+    list.todos['1'] = {
+      title: 'Buy milk',
       completed: false,
     };
     expect(fn).toHaveBeenCalledTimes(2);
     expect(fn).toHaveBeenCalledWith({
-      "1": {
-        title: "Buy milk",
+      '1': {
+        title: 'Buy milk',
         completed: false,
       },
     });
-    list.todos["2"] = {
-      title: "Buy milk",
+    list.todos['2'] = {
+      title: 'Buy milk',
       completed: false,
     };
     expect(fn).toHaveBeenCalledTimes(3);
-    delete list.todos["1"];
+    delete list.todos['1'];
     expect(fn).toHaveBeenCalledTimes(4);
     unwatch();
   });
@@ -101,7 +101,7 @@ describe('watch', () => {
     state.items.push(2);
     expect(fn).toHaveBeenCalledTimes(3);
     unwatch();
-  })
+  });
 });
 
 describe('watch with batch', () => {

--- a/tests/01_watch.spec.ts
+++ b/tests/01_watch.spec.ts
@@ -30,7 +30,10 @@ describe('watch', () => {
   });
 
   it('should work with nested object', async () => {
-    const state = proxy({ count: 0, nested: { count: 0, anotherCount: 0 } });
+    const state = proxy({
+      count: 0,
+      nested: { count: 0, anotherCount: 0, anotherObject: { count2: 0 } },
+    });
     const data: number[] = [];
     const unwatch = watch(() => {
       data.push(state.nested.count);
@@ -41,6 +44,8 @@ describe('watch', () => {
     ++state.count;
     expect(data).toEqual([0, 1]);
     ++state.nested.anotherCount;
+    expect(data).toEqual([0, 1]);
+    ++state.nested.anotherObject.count2;
     expect(data).toEqual([0, 1]);
     unwatch();
   });


### PR DESCRIPTION
When doing something like this:

```ts
effect(() => {
  state.todos.forEach((todo) => console.log(todo));
});
```

I'd expect it to run when I add/remove items from the todo list. This change adds this in a pretty naive way by looking to see if the keys have changed on objects and arrays.