### PR TITLE
fix: removed watch from export

### DIFF
--- a/examples/01_watch/src/app.tsx
+++ b/examples/01_watch/src/app.tsx
@@ -1,9 +1,9 @@
 import { proxy, useSnapshot } from 'valtio';
-import { unstable_watch as watch } from 'valtio-reactive';
+import { effect } from 'valtio-reactive';
 
 const state = proxy({ count: 0 });
 
-watch(() => {
+effect(() => {
   console.log(state.count);
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { batch, watch as unstable_watch } from './core.js';
+export { batch } from './core.js';
 export { computed } from './computed.js';
 export { effect } from './effect.js';

--- a/tests/01_watch.spec.ts
+++ b/tests/01_watch.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { proxy } from 'valtio';
-import { batch, unstable_watch as watch } from 'valtio-reactive';
+import { batch } from 'valtio-reactive';
+import { watch } from '../src/core.js';
 
 describe('watch', () => {
   it('should run function initially', async () => {


### PR DESCRIPTION
- Removed `watch` from export in index
- Updated watch import for tests to use relative path 
- Updated watch import to use effect in example